### PR TITLE
feat(installer): preselect firmware channel via ?channel= deep link

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -255,6 +255,16 @@ watch(showOldVersions, (show) => {
   }
 });
 
+// Optional ?channel= deep link (e.g. from the Discord release announcement):
+// "beta"/"stable" select that channel; a specific version tag is honoured only
+// if it exists in the index (validated below to avoid arbitrary fetch paths).
+const requestedChannel = new URLSearchParams(window.location.search).get(
+  "channel"
+);
+if (requestedChannel === "beta" || requestedChannel === "stable") {
+  firmwareVersion.value = requestedChannel;
+}
+
 const loadFirmwareIndex = async () => {
   try {
     const res = await fetch(
@@ -263,6 +273,15 @@ const loadFirmwareIndex = async () => {
     if (res.ok) firmwareIndex.value = await res.json();
   } catch (e) {
     // Fall back to the static stable/beta options.
+  }
+  if (
+    requestedChannel &&
+    requestedChannel !== "beta" &&
+    requestedChannel !== "stable" &&
+    firmwareIndex.value?.stable.versions.includes(requestedChannel)
+  ) {
+    showOldVersions.value = true;
+    firmwareVersion.value = requestedChannel;
   }
 };
 loadFirmwareIndex();


### PR DESCRIPTION
## Summary

Lets the firmware installer be deep-linked to a specific channel via a
`?channel=` query param, so the Discord release announcement can link straight
to the right build instead of defaulting to stable.

## Behaviour

- `?channel=beta` / `?channel=stable` → selects that channel on load.
- `?channel=<version-tag>` → selects that version **only if it exists in
  `index.json`** (validated to avoid arbitrary fetch paths) and enables the
  "show old versions" toggle so it appears in the dropdown.
- No param → unchanged (defaults to stable).

## Verification

- Headless browser (CDP) confirms the firmware `<select>` value is `beta` with
  `?channel=beta` and `stable` with no param.
- `npm run build` passes.