### PR TITLE
fix(dev): exclude vue-i18n from dependency optimizer

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,6 +21,13 @@ export default defineConfig({
     }),
   ],
   base: "/Schnell-Keypad-Configuration-Tool/",
+  // Vite 8's (rolldown) dependency optimizer emits a broken pre-bundle for
+  // vue-i18n ("init_runtime_dom_esm_bundler is not defined"), blanking the dev
+  // app. Serve it as native ESM instead of pre-bundling it. Dev-only; the
+  // production build is unaffected.
+  optimizeDeps: {
+    exclude: ["vue-i18n"],
+  },
   resolve: {
     alias: {
       "@": fileURLToPath(new URL("./src", import.meta.url)),


### PR DESCRIPTION
Vite 8's (rolldown) dependency optimizer emits a broken pre-bundle for `vue-i18n` — it references `init_runtime_dom_esm_bundler` without defining it, throwing `Uncaught ReferenceError` and leaving the **dev** app blank (white screen on `master`).

Exclude `vue-i18n` from `optimizeDeps` so Vite serves it as native ESM instead of pre-bundling it. Dev-only — the production build does not use `optimizeDeps`, so it's unaffected (`npm run build` still passes).

Verified: after the change `node_modules/.vite/deps` no longer contains the broken `vue-i18n` bundle and the dev server starts clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)