### PR TITLE
feat(ui): confirm dialogs for device read/upload + remember language

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -51,6 +51,7 @@ import { key } from "./store";
 import { FwbToast } from "flowbite-vue";
 import ToggleCheckbox from "@/components/ToggleCheckbox.vue";
 import SerialConnection from "./components/SerialConnection.vue";
+import Modal from "@/components/Modal.vue";
 
 const store = useStore(key);
 
@@ -317,8 +318,9 @@ watch(macroIndex, async () => {
 const initializeApp = async () => {
   // Connect to the device
   try {
-    const userLocale = navigator.language || navigator.languages[0];
-    i18n.locale.value = userLocale;
+    const savedLocale = localStorage.getItem("locale");
+    i18n.locale.value =
+      savedLocale || navigator.language || navigator.languages[0];
     isKeyboardConnected.value = false;
     const response = await fetch(`${keyboardUrl.value}/api/network`);
     const data = await response.json();
@@ -672,6 +674,8 @@ const uploadConfigToDevice = async (type: string) => {
  */
 const updatePageTitle = () => {
   document.title = i18n.t("navTitle");
+  // Remember the user's language choice across visits.
+  localStorage.setItem("locale", i18n.locale.value);
 };
 
 /**
@@ -771,6 +775,31 @@ const onSerialConfigRead = (configJsonString: string) => {
       type: "danger",
     });
   }
+};
+
+// Confirmation modal shared by the device read / upload actions.
+const confirmOpen = ref(false);
+const confirmMessage = ref("");
+let confirmAction: (() => void) | null = null;
+
+const askConfirm = (message: string, action: () => void) => {
+  confirmMessage.value = message;
+  confirmAction = action;
+  confirmOpen.value = true;
+};
+
+const onConfirm = () => {
+  const action = confirmAction;
+  confirmAction = null;
+  if (action) action();
+};
+
+const confirmReadFromDevice = () => {
+  askConfirm(i18n.t("confirmReadFromDevice"), readConfigFromDevice);
+};
+
+const confirmUploadToDevice = (type: string) => {
+  askConfirm(i18n.t("confirmUploadToDevice"), () => uploadConfigToDevice(type));
 };
 
 /**
@@ -985,6 +1014,18 @@ initializeLayout();
       class="flex justify-center mt-4"
       @config-read="onSerialConfigRead"
     />
+
+    <Modal
+      v-model:isOpen="confirmOpen"
+      :title="$t('confirmTitle')"
+      :confirmText="$t('confirm')"
+      :cancelText="$t('cancel')"
+      @confirm="onConfirm"
+    >
+      <template #body>
+        <p class="text-sm text-gray-600 mt-2">{{ confirmMessage }}</p>
+      </template>
+    </Modal>
     <div class="flex justify-center mt-4">
       <div class="flex">
         <div>
@@ -1051,7 +1092,7 @@ initializeLayout();
         <button
           name="read"
           class="btn btn-export grow flex"
-          @click="readConfigFromDevice"
+          @click="confirmReadFromDevice"
           :disabled="!isKeyboardConnected"
         >
           <tray-arrow-down-icon :size="24" class="self-center mr-2" />
@@ -1061,7 +1102,7 @@ initializeLayout();
         <button
           name="export"
           class="btn btn-export grow flex"
-          @click="uploadConfigToDevice('keyconfig')"
+          @click="confirmUploadToDevice('keyconfig')"
           :disabled="!isKeyboardConnected"
         >
           <cloud-upload-icon :size="24" class="self-center mr-2" />

--- a/src/App.vue
+++ b/src/App.vue
@@ -1023,7 +1023,9 @@ initializeLayout();
       @confirm="onConfirm"
     >
       <template #body>
-        <p class="text-sm text-gray-600 mt-2">{{ confirmMessage }}</p>
+        <p class="text-sm text-gray-600 dark:text-gray-300 mt-2">
+          {{ confirmMessage }}
+        </p>
       </template>
     </Modal>
     <div class="flex justify-center mt-4">

--- a/src/components/Modal.vue
+++ b/src/components/Modal.vue
@@ -4,20 +4,20 @@
       class="flex items-center justify-center min-h-screen px-4 pt-4 pb-20 text-center sm:block sm:p-0"
     >
       <div
-        class="fixed inset-0 transition-opacity"
+        class="fixed inset-0 bg-black bg-opacity-50 transition-opacity"
         aria-hidden="true"
         @click="closeModal"
       ></div>
       <div
-        class="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full"
+        class="inline-block align-bottom bg-white dark:bg-stone-800 rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full"
         role="dialog"
         aria-modal="true"
         aria-labelledby="modal-headline"
       >
-        <div class="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+        <div class="bg-white dark:bg-stone-800 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
           <slot name="header">
             <h3
-              class="text-lg leading-6 font-medium text-gray-900"
+              class="text-lg leading-6 font-medium text-gray-900 dark:text-gray-100"
               id="modal-headline"
             >
               {{ title }}
@@ -25,7 +25,9 @@
           </slot>
           <slot name="body"></slot>
         </div>
-        <div class="bg-gray-50 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
+        <div
+          class="bg-gray-50 dark:bg-stone-900 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse"
+        >
           <slot name="footer">
             <button
               type="button"
@@ -37,7 +39,7 @@
             <button
               v-if="showCancel"
               type="button"
-              class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm"
+              class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 dark:border-stone-600 shadow-sm px-4 py-2 bg-white dark:bg-stone-700 text-base font-medium text-gray-700 dark:text-gray-200 hover:text-gray-500 dark:hover:text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm"
               @click="onCancel"
             >
               {{ cancelText }}

--- a/src/components/Modal.vue
+++ b/src/components/Modal.vue
@@ -30,17 +30,17 @@
             <button
               type="button"
               class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-green-600 text-base font-medium text-white hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 sm:ml-3 sm:w-auto sm:text-sm"
-              @click="closeModal"
+              @click="onConfirm"
             >
-              OK
+              {{ confirmText }}
             </button>
             <button
               v-if="showCancel"
               type="button"
               class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm"
-              @click="closeModal"
+              @click="onCancel"
             >
-              Cancel
+              {{ cancelText }}
             </button>
           </slot>
         </div>
@@ -64,10 +64,27 @@ export default {
       type: Boolean,
       default: true,
     },
+    confirmText: {
+      type: String,
+      default: "OK",
+    },
+    cancelText: {
+      type: String,
+      default: "Cancel",
+    },
   },
+  emits: ["update:isOpen", "confirm", "cancel"],
   methods: {
     closeModal() {
       this.$emit("update:isOpen", false);
+    },
+    onConfirm() {
+      this.$emit("confirm");
+      this.closeModal();
+    },
+    onCancel() {
+      this.$emit("cancel");
+      this.closeModal();
     },
   },
 };

--- a/src/components/SerialConnection.vue
+++ b/src/components/SerialConnection.vue
@@ -200,7 +200,9 @@ const readConfigViaSerial = async () => {
       @confirm="onConfirm"
     >
       <template #body>
-        <p class="text-sm text-gray-600 mt-2">{{ confirmMessage }}</p>
+        <p class="text-sm text-gray-600 dark:text-gray-300 mt-2">
+          {{ confirmMessage }}
+        </p>
       </template>
     </Modal>
   </div>

--- a/src/components/SerialConnection.vue
+++ b/src/components/SerialConnection.vue
@@ -1,10 +1,13 @@
 <script setup lang="ts">
 import { ref } from "vue";
+import { useI18n } from "vue-i18n";
 import UsbIcon from "icons/Usb.vue";
 import MathLogIcon from "icons/MathLog.vue";
 import ConnectionIcon from "icons/Connection.vue";
 import TrayArrowDownIcon from "icons/TrayArrowDown.vue";
+import Modal from "@/components/Modal.vue";
 
+const { t } = useI18n();
 const serialInput = ref("");
 const serialOutput = ref("");
 const port = ref<any | null>(null);
@@ -13,6 +16,31 @@ const showSerialMonitor = ref(false);
 const isConnected = ref(false); // New variable to check if serial device is connected
 const props = defineProps(["configString"]);
 const emit = defineEmits(["config-read"]);
+
+// Confirmation modal shared by the serial read / upload actions.
+const confirmOpen = ref(false);
+const confirmMessage = ref("");
+let confirmAction: (() => void) | null = null;
+
+const askConfirm = (message: string, action: () => void) => {
+  confirmMessage.value = message;
+  confirmAction = action;
+  confirmOpen.value = true;
+};
+
+const onConfirm = () => {
+  const action = confirmAction;
+  confirmAction = null;
+  if (action) action();
+};
+
+const confirmReadConfig = () => {
+  askConfirm(t("confirmReadFromDevice"), readConfigViaSerial);
+};
+
+const confirmUpdateConfig = () => {
+  askConfirm(t("confirmUploadToDevice"), updateConfigViaSerial);
+};
 
 const openSerialRequest = async () => {
   try {
@@ -140,7 +168,7 @@ const readConfigViaSerial = async () => {
       </button>
       <button
         class="btn btn-export grow flex"
-        @click="readConfigViaSerial"
+        @click="confirmReadConfig"
         :disabled="!isConnected"
       >
         <tray-arrow-down-icon :size="24" class="self-center mr-2" />
@@ -148,7 +176,7 @@ const readConfigViaSerial = async () => {
       </button>
       <button
         class="btn btn-export grow flex"
-        @click="updateConfigViaSerial"
+        @click="confirmUpdateConfig"
         :disabled="!isConnected"
       >
         <usb-icon :size="24" class="self-center mr-2" />
@@ -163,5 +191,17 @@ const readConfigViaSerial = async () => {
     >
       {{ serialOutput }}
     </div>
+
+    <Modal
+      v-model:isOpen="confirmOpen"
+      :title="$t('confirmTitle')"
+      :confirmText="$t('confirm')"
+      :cancelText="$t('cancel')"
+      @confirm="onConfirm"
+    >
+      <template #body>
+        <p class="text-sm text-gray-600 mt-2">{{ confirmMessage }}</p>
+      </template>
+    </Modal>
   </div>
 </template>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -41,5 +41,10 @@
   "baudRate": "Baud Rate",
   "openSerialConnection": "Open Serial Connection",
   "toggleSerialMonitor": "Toggle Serial Monitor",
-  "readKeyConfigFromDevice": "Read Configuration from Device"
+  "readKeyConfigFromDevice": "Read Configuration from Device",
+  "confirm": "Confirm",
+  "cancel": "Cancel",
+  "confirmTitle": "Please confirm",
+  "confirmReadFromDevice": "Read the configuration from the device? This will replace the configuration currently in the editor.",
+  "confirmUploadToDevice": "Upload the current configuration to the device? This will overwrite the configuration stored on the device."
 }

--- a/src/locales/zh-cn.json
+++ b/src/locales/zh-cn.json
@@ -41,5 +41,10 @@
   "baudRate": "波特率",
   "openSerialConnection": "开启串口 (USB)",
   "toggleSerialMonitor": "切换串口监视器",
-  "readKeyConfigFromDevice": "从装置读取设置文件"
+  "readKeyConfigFromDevice": "从装置读取设置文件",
+  "confirm": "确认",
+  "cancel": "取消",
+  "confirmTitle": "请确认",
+  "confirmReadFromDevice": "要从装置读取设置文件吗?这会覆盖编辑器中当前的设置。",
+  "confirmUploadToDevice": "要将当前设置上传到装置吗?这会覆盖装置上保存的设置。"
 }

--- a/src/locales/zh-tw.json
+++ b/src/locales/zh-tw.json
@@ -41,5 +41,10 @@
   "baudRate": "傳輸速率",
   "openSerialConnection": "開啟序列通訊 (USB)",
   "toggleSerialMonitor": "切換序列通訊監控顯示",
-  "readKeyConfigFromDevice": "從裝置讀取設定檔"
+  "readKeyConfigFromDevice": "從裝置讀取設定檔",
+  "confirm": "確認",
+  "cancel": "取消",
+  "confirmTitle": "請確認",
+  "confirmReadFromDevice": "要從裝置讀取設定檔嗎?這會覆蓋編輯器中目前的設定。",
+  "confirmUploadToDevice": "要將目前的設定上傳到裝置嗎?這會覆蓋裝置上儲存的設定。"
 }


### PR DESCRIPTION
Two UI improvements.

### 1. Confirmation before device read / upload
Reading from or uploading to the device now asks for confirmation first, over **both** transports (web and serial). Uses the existing `Modal.vue` (enhanced to emit `confirm` / `cancel`) — no native `alert()` / `confirm()`.

- Web read / upload buttons (App.vue) and serial read / upload buttons (SerialConnection.vue) open a confirm dialog; the action only runs on confirm.
- Added i18n strings `confirmTitle` / `confirmReadFromDevice` / `confirmUploadToDevice` / `confirm` / `cancel` (en / zh-tw / zh-cn).

### 2. Remember language choice
The selected language is saved to `localStorage` and restored on load (falling back to the browser locale). Previously it reset to the browser locale every visit.

`npm run build` passes; dev server starts clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)