### PR TITLE
feat: configure device WiFi over serial

### DIFF
--- a/src/assets/scss/index.scss
+++ b/src/assets/scss/index.scss
@@ -77,8 +77,15 @@ select:focus {
 }
 
 .text-input {
-    @apply rounded border-solid border-2 border-stone-300 py-1 px-2 ml-1 m-1 
+    @apply rounded border-solid border-2 border-stone-300 py-1 px-2 ml-1 m-1
     focus:border-lime-600 dark:bg-stone-800 dark:border-black dark:text-neutral-400;
+}
+
+// Filled, borderless field matching the app's .label / drag-drop-bar surfaces.
+.input-filled {
+    @apply rounded border-none bg-stone-200 text-stone-600 py-2 px-3 m-0
+    dark:bg-stone-700 dark:text-neutral-200
+    focus:outline-none focus:ring-0 disabled:opacity-50;
 }
 
 .btn {

--- a/src/components/SerialConnection.vue
+++ b/src/components/SerialConnection.vue
@@ -26,6 +26,9 @@ const wifiPassword = ref("");
 // Networks scanned by the device, offered as SSID suggestions.
 const wifiNetworks = ref<{ ssid: string; rssi: number }[]>([]);
 const scanningWifi = ref(false);
+// True while any WiFi serial exchange (read or scan) is in flight, so the
+// dialog's controls stay disabled and can't race a second command.
+const wifiBusy = ref(false);
 
 // Confirmation modal shared by the serial read / upload actions.
 const confirmOpen = ref(false);
@@ -237,16 +240,21 @@ const openWifiModal = async () => {
   wifiPassword.value = "";
   showWifiModal.value = true;
 
-  const res = await requestJsonViaSerial(
-    "READ_WIFI",
-    "<<<WIFI_BEGIN>>>",
-    "<<<WIFI_END>>>",
-    5000
-  );
-  if (res) wifiSsid.value = res.ssid ?? "";
+  wifiBusy.value = true;
+  try {
+    const res = await requestJsonViaSerial(
+      "READ_WIFI",
+      "<<<WIFI_BEGIN>>>",
+      "<<<WIFI_END>>>",
+      5000
+    );
+    if (res) wifiSsid.value = res.ssid ?? "";
 
-  // Sequential, not concurrent: the device reads one serial command at a time.
-  await scanWifiViaSerial();
+    // Sequential, not concurrent: the device reads one serial command at a time.
+    await scanWifiViaSerial();
+  } finally {
+    wifiBusy.value = false;
+  }
 };
 
 // Persist the entered WiFi credentials to the device. The "WRITE_WIFI" prefix
@@ -334,13 +342,7 @@ const updateWifiViaSerial = async () => {
       </template>
     </Modal>
 
-    <Modal
-      v-model:isOpen="showWifiModal"
-      :title="$t('configureWifi')"
-      :confirmText="$t('confirm')"
-      :cancelText="$t('cancel')"
-      @confirm="updateWifiViaSerial"
-    >
+    <Modal v-model:isOpen="showWifiModal" :title="$t('configureWifi')">
       <template #body>
         <div class="mt-4 flex flex-col space-y-3 text-left">
           <label class="flex flex-col text-sm text-gray-600 dark:text-gray-300">
@@ -349,7 +351,7 @@ const updateWifiViaSerial = async () => {
               <button
                 type="button"
                 class="text-xs text-cyan-600 dark:text-cyan-400 hover:underline disabled:opacity-50 disabled:no-underline"
-                :disabled="scanningWifi"
+                :disabled="wifiBusy || scanningWifi"
                 @click="scanWifiViaSerial"
               >
                 {{ scanningWifi ? $t("wifiScanning") : $t("wifiRescan") }}
@@ -393,6 +395,25 @@ const updateWifiViaSerial = async () => {
             {{ $t("wifiConfigHint") }}
           </p>
         </div>
+      </template>
+      <!-- Custom footer so the dialog only closes on a successful save, and
+           Confirm is blocked while busy or when no SSID is set. -->
+      <template #footer>
+        <button
+          type="button"
+          class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-green-600 text-base font-medium text-white hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 disabled:opacity-50 disabled:hover:bg-green-600 sm:ml-3 sm:w-auto sm:text-sm"
+          :disabled="wifiBusy || scanningWifi || !wifiSsid"
+          @click="updateWifiViaSerial"
+        >
+          {{ $t("confirm") }}
+        </button>
+        <button
+          type="button"
+          class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 dark:border-stone-600 shadow-sm px-4 py-2 bg-white dark:bg-stone-700 text-base font-medium text-gray-700 dark:text-gray-200 hover:text-gray-500 dark:hover:text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm"
+          @click="showWifiModal = false"
+        >
+          {{ $t("cancel") }}
+        </button>
       </template>
     </Modal>
   </div>

--- a/src/components/SerialConnection.vue
+++ b/src/components/SerialConnection.vue
@@ -5,6 +5,7 @@ import UsbIcon from "icons/Usb.vue";
 import MathLogIcon from "icons/MathLog.vue";
 import ConnectionIcon from "icons/Connection.vue";
 import TrayArrowDownIcon from "icons/TrayArrowDown.vue";
+import WifiSettingsIcon from "icons/WifiSettings.vue";
 import Modal from "@/components/Modal.vue";
 
 const { t } = useI18n();
@@ -16,6 +17,15 @@ const showSerialMonitor = ref(false);
 const isConnected = ref(false); // New variable to check if serial device is connected
 const props = defineProps(["configString"]);
 const emit = defineEmits(["config-read"]);
+
+// WiFi credentials sent to the device over serial (persisted to its
+// config.json and used the next time it boots into WiFi mode).
+const showWifiModal = ref(false);
+const wifiSsid = ref("");
+const wifiPassword = ref("");
+// Networks scanned by the device, offered as SSID suggestions.
+const wifiNetworks = ref<{ ssid: string; rssi: number }[]>([]);
+const scanningWifi = ref(false);
 
 // Confirmation modal shared by the serial read / upload actions.
 const confirmOpen = ref(false);
@@ -141,6 +151,116 @@ const readConfigViaSerial = async () => {
   }
   console.error("Timed out waiting for config from device");
 };
+
+// Write a single string to the serial port. Returns true on success.
+const writeSerial = async (data: string): Promise<boolean> => {
+  if (!port.value || !port.value.writable) {
+    console.error("Serial port is not open");
+    return false;
+  }
+  const writer = port.value.writable.getWriter();
+  try {
+    await writer.write(new TextEncoder().encode(data));
+    return true;
+  } catch (error) {
+    console.error("Error sending serial data:", error);
+    return false;
+  } finally {
+    writer.releaseLock();
+  }
+};
+
+// Send a command, then wait for a JSON object delimited by the given markers
+// in the serial output. Returns the parsed object, or null on timeout / no
+// JSON / parse error.
+const requestJsonViaSerial = async (
+  command: string,
+  begin: string,
+  end: string,
+  timeoutMs: number
+): Promise<any | null> => {
+  const searchStart = serialOutput.value.length;
+  if (!(await writeSerial(command))) return null;
+
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const buf = serialOutput.value;
+    const b = buf.indexOf(begin, searchStart);
+    const e = b !== -1 ? buf.indexOf(end, b + begin.length) : -1;
+    if (b !== -1 && e !== -1) {
+      const between = buf.slice(b + begin.length, e);
+      const open = between.indexOf("{");
+      const close = between.lastIndexOf("}");
+      if (open === -1 || close <= open) return null;
+      try {
+        return JSON.parse(between.slice(open, close + 1));
+      } catch {
+        console.error("Failed to parse device response:", command);
+        return null;
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  console.error("Timed out waiting for device response:", command);
+  return null;
+};
+
+// Ask the device to scan for nearby networks and populate the SSID
+// suggestions (strongest signal first, de-duplicated across APs/bands).
+const scanWifiViaSerial = async () => {
+  if (scanningWifi.value) return;
+  scanningWifi.value = true;
+  try {
+    const res = await requestJsonViaSerial(
+      "SCAN_WIFI",
+      "<<<WIFISCAN_BEGIN>>>",
+      "<<<WIFISCAN_END>>>",
+      10000
+    );
+    if (!res) return;
+    const seen = new Set<string>();
+    wifiNetworks.value = (res.networks ?? [])
+      .sort((a: any, b: any) => b.rssi - a.rssi)
+      .filter((n: any) => {
+        if (!n.ssid || seen.has(n.ssid)) return false;
+        seen.add(n.ssid);
+        return true;
+      });
+  } finally {
+    scanningWifi.value = false;
+  }
+};
+
+// Open the WiFi dialog, pre-fill the SSID currently stored on the device
+// (the password is never returned), then scan for nearby networks.
+const openWifiModal = async () => {
+  wifiPassword.value = "";
+  showWifiModal.value = true;
+
+  const res = await requestJsonViaSerial(
+    "READ_WIFI",
+    "<<<WIFI_BEGIN>>>",
+    "<<<WIFI_END>>>",
+    5000
+  );
+  if (res) wifiSsid.value = res.ssid ?? "";
+
+  // Sequential, not concurrent: the device reads one serial command at a time.
+  await scanWifiViaSerial();
+};
+
+// Persist the entered WiFi credentials to the device. The "WRITE_WIFI" prefix
+// tells the firmware to save the trailing JSON to its config.json.
+const updateWifiViaSerial = async () => {
+  if (!wifiSsid.value) return;
+  const payload = JSON.stringify({
+    ssid: wifiSsid.value,
+    password: wifiPassword.value,
+  });
+  if (await writeSerial("WRITE_WIFI" + payload)) {
+    showWifiModal.value = false;
+  }
+};
 </script>
 
 <template>
@@ -182,6 +302,14 @@ const readConfigViaSerial = async () => {
         <usb-icon :size="24" class="self-center mr-2" />
         {{ $t("uploadKeyConfigToDevice") }}
       </button>
+      <button
+        class="btn btn-export grow flex"
+        @click="openWifiModal"
+        :disabled="!isConnected"
+      >
+        <wifi-settings-icon :size="24" class="self-center mr-2" />
+        {{ $t("configureWifi") }}
+      </button>
     </div>
 
     <div
@@ -203,6 +331,68 @@ const readConfigViaSerial = async () => {
         <p class="text-sm text-gray-600 dark:text-gray-300 mt-2">
           {{ confirmMessage }}
         </p>
+      </template>
+    </Modal>
+
+    <Modal
+      v-model:isOpen="showWifiModal"
+      :title="$t('configureWifi')"
+      :confirmText="$t('confirm')"
+      :cancelText="$t('cancel')"
+      @confirm="updateWifiViaSerial"
+    >
+      <template #body>
+        <div class="mt-4 flex flex-col space-y-3 text-left">
+          <label class="flex flex-col text-sm text-gray-600 dark:text-gray-300">
+            <span class="mb-1 flex items-center justify-between">
+              {{ $t("wifiScannedNetworks") }}
+              <button
+                type="button"
+                class="text-xs text-cyan-600 dark:text-cyan-400 hover:underline disabled:opacity-50 disabled:no-underline"
+                :disabled="scanningWifi"
+                @click="scanWifiViaSerial"
+              >
+                {{ scanningWifi ? $t("wifiScanning") : $t("wifiRescan") }}
+              </button>
+            </span>
+            <select
+              class="input-filled w-full cursor-pointer"
+              :value="wifiSsid"
+              :disabled="scanningWifi || wifiNetworks.length === 0"
+              @change="wifiSsid = ($event.target as HTMLSelectElement).value"
+            >
+              <option value="" disabled>{{ $t("wifiSelectNetwork") }}</option>
+              <option
+                v-for="net in wifiNetworks"
+                :key="net.ssid"
+                :value="net.ssid"
+              >
+                {{ net.ssid }}
+              </option>
+            </select>
+          </label>
+          <label class="flex flex-col text-sm text-gray-600 dark:text-gray-300">
+            <span class="mb-1">{{ $t("wifiSsid") }}</span>
+            <input
+              v-model="wifiSsid"
+              type="text"
+              class="input-filled w-full"
+              autocomplete="off"
+            />
+          </label>
+          <label class="flex flex-col text-sm text-gray-600 dark:text-gray-300">
+            <span class="mb-1">{{ $t("wifiPassword") }}</span>
+            <input
+              v-model="wifiPassword"
+              type="password"
+              class="input-filled w-full"
+              autocomplete="off"
+            />
+          </label>
+          <p class="text-xs text-gray-500 dark:text-gray-400">
+            {{ $t("wifiConfigHint") }}
+          </p>
+        </div>
       </template>
     </Modal>
   </div>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -46,5 +46,13 @@
   "cancel": "Cancel",
   "confirmTitle": "Please confirm",
   "confirmReadFromDevice": "Read the configuration from the device? This will replace the configuration currently in the editor.",
-  "confirmUploadToDevice": "Upload the current configuration to the device? This will overwrite the configuration stored on the device."
+  "confirmUploadToDevice": "Upload the current configuration to the device? This will overwrite the configuration stored on the device.",
+  "configureWifi": "Configure WiFi",
+  "wifiSsid": "Network name (SSID)",
+  "wifiPassword": "Password",
+  "wifiConfigHint": "Credentials are saved to the device and used the next time it boots into WiFi mode.",
+  "wifiRescan": "Rescan",
+  "wifiScanning": "Scanning...",
+  "wifiScannedNetworks": "Nearby networks",
+  "wifiSelectNetwork": "Select a network..."
 }

--- a/src/locales/zh-cn.json
+++ b/src/locales/zh-cn.json
@@ -46,5 +46,13 @@
   "cancel": "取消",
   "confirmTitle": "请确认",
   "confirmReadFromDevice": "要从装置读取设置文件吗?这会覆盖编辑器中当前的设置。",
-  "confirmUploadToDevice": "要将当前设置上传到装置吗?这会覆盖装置上保存的设置。"
+  "confirmUploadToDevice": "要将当前设置上传到装置吗?这会覆盖装置上保存的设置。",
+  "configureWifi": "设置 WiFi",
+  "wifiSsid": "网络名称 (SSID)",
+  "wifiPassword": "密码",
+  "wifiConfigHint": "账号密码会保存到装置，并在下次进入 WiFi 模式时使用。",
+  "wifiRescan": "重新扫描",
+  "wifiScanning": "扫描中...",
+  "wifiScannedNetworks": "附近的网络",
+  "wifiSelectNetwork": "选择网络..."
 }

--- a/src/locales/zh-tw.json
+++ b/src/locales/zh-tw.json
@@ -46,5 +46,13 @@
   "cancel": "取消",
   "confirmTitle": "請確認",
   "confirmReadFromDevice": "要從裝置讀取設定檔嗎?這會覆蓋編輯器中目前的設定。",
-  "confirmUploadToDevice": "要將目前的設定上傳到裝置嗎?這會覆蓋裝置上儲存的設定。"
+  "confirmUploadToDevice": "要將目前的設定上傳到裝置嗎?這會覆蓋裝置上儲存的設定。",
+  "configureWifi": "設定 WiFi",
+  "wifiSsid": "網路名稱 (SSID)",
+  "wifiPassword": "密碼",
+  "wifiConfigHint": "帳號密碼會儲存到裝置，並在下次進入 WiFi 模式時使用。",
+  "wifiRescan": "重新掃描",
+  "wifiScanning": "掃描中...",
+  "wifiScannedNetworks": "附近的網路",
+  "wifiSelectNetwork": "選擇網路..."
 }


### PR DESCRIPTION
## Summary

Adds a **Configure WiFi** action to the serial panel so the device's WiFi can be set over the existing Web Serial connection (no need to first join the device's AP). Pairs with the firmware's new `READ_WIFI` / `SCAN_WIFI` / `WRITE_WIFI` serial commands.

Opening the dialog:
- reads the SSID currently stored on the device (`READ_WIFI`) to pre-fill the form,
- scans for nearby networks (`SCAN_WIFI`) and offers them in a dropdown (strongest signal first, de-duplicated), while still allowing a manually typed SSID,
- on confirm, sends the credentials via `WRITE_WIFI`.

## Notes

- Factored the marker-delimited serial request/response into a shared `requestJsonViaSerial()` helper (also used by the read/scan flows).
- New filled, borderless `.input-filled` class matching the app's existing surfaces and dark mode.
- i18n strings added for en / zh-tw / zh-cn.

## Testing

- `vue-tsc --noEmit` passes; all locale JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)